### PR TITLE
Optimize dish and category management flows

### DIFF
--- a/sky-server/src/main/java/com/sky/mapper/SetMealMapper.java
+++ b/sky-server/src/main/java/com/sky/mapper/SetMealMapper.java
@@ -12,6 +12,6 @@ public interface SetMealMapper {
      * @return
      */
     @Select("select count(id) from setmeal where category_id = #{categoryId}")
-    Integer countByCategoryId(Long id);
+    Integer countByCategoryId(Long categoryId);
 
 }

--- a/sky-server/src/main/java/com/sky/service/impl/CategoryServiceImpl.java
+++ b/sky-server/src/main/java/com/sky/service/impl/CategoryServiceImpl.java
@@ -33,7 +33,7 @@ public class CategoryServiceImpl implements CategoryService {
     @Autowired
     private DishMapper dishMapper;
     @Autowired
-    private SetMealMapper setmealMapper;
+    private SetMealMapper setMealMapper;
 
     /**
      * 新增分类
@@ -47,11 +47,14 @@ public class CategoryServiceImpl implements CategoryService {
         //分类状态默认为禁用状态0
         category.setStatus(StatusConstant.DISABLE);
 
+        LocalDateTime now = LocalDateTime.now();
+        Long currentId = BaseContext.getCurrentId();
+
         //设置创建时间、修改时间、创建人、修改人
-        category.setCreateTime(LocalDateTime.now());
-        category.setUpdateTime(LocalDateTime.now());
-        category.setCreateUser(BaseContext.getCurrentId());
-        category.setUpdateUser(BaseContext.getCurrentId());
+        category.setCreateTime(now);
+        category.setUpdateTime(now);
+        category.setCreateUser(currentId);
+        category.setUpdateUser(currentId);
 
         categoryMapper.insert(category);
     }
@@ -81,7 +84,7 @@ public class CategoryServiceImpl implements CategoryService {
         }
 
         //查询当前分类是否关联了套餐，如果关联了就抛出业务异常
-        count = setmealMapper.countByCategoryId(id);
+        count = setMealMapper.countByCategoryId(id);
         if(count > 0){
             //当前分类下有菜品，不能删除
             throw new DeletionNotAllowedException(MessageConstant.CATEGORY_BE_RELATED_BY_SETMEAL);
@@ -100,8 +103,10 @@ public class CategoryServiceImpl implements CategoryService {
         BeanUtils.copyProperties(categoryDTO,category);
 
         //设置修改时间、修改人
-        category.setUpdateTime(LocalDateTime.now());
-        category.setUpdateUser(BaseContext.getCurrentId());
+        LocalDateTime now = LocalDateTime.now();
+        Long currentId = BaseContext.getCurrentId();
+        category.setUpdateTime(now);
+        category.setUpdateUser(currentId);
 
         categoryMapper.update(category);
     }
@@ -112,11 +117,13 @@ public class CategoryServiceImpl implements CategoryService {
      * @param id
      */
     public void startOrStop(Integer status, Long id) {
+        LocalDateTime now = LocalDateTime.now();
+        Long currentId = BaseContext.getCurrentId();
         Category category = Category.builder()
                 .id(id)
                 .status(status)
-                .updateTime(LocalDateTime.now())
-                .updateUser(BaseContext.getCurrentId())
+                .updateTime(now)
+                .updateUser(currentId)
                 .build();
         categoryMapper.update(category);
     }

--- a/sky-server/src/main/java/com/sky/service/impl/DishServiceImpl.java
+++ b/sky-server/src/main/java/com/sky/service/impl/DishServiceImpl.java
@@ -20,10 +20,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -44,7 +45,10 @@ public class DishServiceImpl implements DishService {
         dishMapper.add(dish);
         Long id = dish.getId();
 
-        dishFlavorMapper.addBatch(id, dishDTO.getFlavors());
+        List<DishFlavor> flavors = dishDTO.getFlavors();
+        if (!CollectionUtils.isEmpty(flavors)) {
+            dishFlavorMapper.addBatch(id, flavors);
+        }
     }
 
     @Override
@@ -64,16 +68,21 @@ public class DishServiceImpl implements DishService {
     @Override
     @Transactional(rollbackFor = Exception.class)
     public void del(List<Long> ids) {
+        if (CollectionUtils.isEmpty(ids)) {
+            return;
+        }
         //起售商品不能删除
         List<Dish> dishList = dishMapper.selectByList(ids);
-        List<Long> collectDel = dishList.stream().filter(dish -> dish.getStatus() == 1)
-                .map(Dish::getId).collect(Collectors.toList());
-        if (!collectDel.isEmpty()) {
+        boolean hasEnabledDish = dishList.stream()
+                .map(Dish::getStatus)
+                .filter(Objects::nonNull)
+                .anyMatch(status -> status.equals(StatusConstant.ENABLE));
+        if (hasEnabledDish) {
             throw new DeletionNotAllowedException(MessageConstant.DISH_ON_SALE);
         }
         //被套餐关联的商品不能删除
         List<Long> dishIds = setMealDishMapper.getMealIdsByDishIds(ids);
-        if (!dishIds.isEmpty()) {
+        if (!CollectionUtils.isEmpty(dishIds)) {
             throw new DeletionNotAllowedException(MessageConstant.DISH_BE_RELATED_BY_SETMEAL);
         }
         //删除菜品关联菜品也进行删除
@@ -108,9 +117,13 @@ public class DishServiceImpl implements DishService {
         //有 有
         //有 空
         //空 空
-        if (!dishDTO.getFlavors().isEmpty()) {
-            dishFlavorMapper.delBatch(Arrays.asList(dish.getId()));
-            dishFlavorMapper.addBatch(dishDTO.getId(), dishDTO.getFlavors());
+        Long dishId = dish.getId();
+        List<DishFlavor> flavors = dishDTO.getFlavors();
+        if (dishId != null) {
+            dishFlavorMapper.delBatch(Collections.singletonList(dishId));
+            if (!CollectionUtils.isEmpty(flavors)) {
+                dishFlavorMapper.addBatch(dishId, flavors);
+            }
         }
 
     }


### PR DESCRIPTION
## Summary
- fix the parameter binding in SetMealMapper so category deletions correctly detect related set meals
- reduce repeated context/time lookups in CategoryService to streamline save and update operations
- harden DishService flavor handling to skip redundant writes and guard empty inputs while deleting safely

## Testing
- mvn -pl sky-server -am -DskipTests compile *(fails: java.lang.NoSuchFieldError: JCTree$JCImport#qualid)*

------
https://chatgpt.com/codex/tasks/task_b_68dd0a62118483228e99c73fc0d73aa3